### PR TITLE
fix: alert monitoring to use existing trigger_alert_rule service

### DIFF
--- a/packages/api/src/services/alert_monitor.py
+++ b/packages/api/src/services/alert_monitor.py
@@ -1,24 +1,15 @@
 """Alert monitoring service for continuous transaction monitoring"""
 
 import asyncio
-from datetime import datetime
 import logging
-import uuid
 
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from db.models import (
-    AlertNotification,
-    AlertRule,
-    NotificationMethod,
-    NotificationStatus,
-    Transaction,
-)
+from db.models import AlertRule, Transaction
 
 from .alert_rule_service import AlertRuleService
-from .notifications import Context, NoopStrategy, SmtpStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +41,6 @@ class AlertMonitorService:
 
     async def _check_transactions_against_rules(self):
         """Check recent transactions against all active alert rules"""
-        # Get a single database session
         session_gen = get_db()
         session = await session_gen.__anext__()
 
@@ -105,170 +95,25 @@ class AlertMonitorService:
             f'Found {len(new_transactions)} new transactions for rule {rule.id}'
         )
 
-        # Check each transaction against the rule
-        for transaction in new_transactions:
-            try:
-                await self._evaluate_transaction_against_rule(
-                    transaction, rule, session
-                )
-            except Exception as e:
-                logger.error(
-                    f'Error evaluating transaction {transaction.id} against rule {rule.id}: {e}'
-                )
-
-    async def _evaluate_transaction_against_rule(
-        self, transaction: Transaction, rule: AlertRule, session: AsyncSession
-    ):
-        """Evaluate a specific transaction against an alert rule"""
-
-        # Use the stored SQL query if available, otherwise generate it
-        if rule.sql_query:
-            sql_query = rule.sql_query
-            logger.debug(f'Using stored SQL query for rule {rule.id}')
-        else:
-            # Generate SQL query using LLM
-            logger.debug(f'Generating SQL query for rule {rule.id}')
-            from .alerts.agents.alert_parser import parse_alert_to_sql_with_context
-
-            transaction_dict = {
-                'user_id': transaction.user_id,
-                'transaction_date': str(transaction.transaction_date),
-                'amount': float(transaction.amount),
-                'merchant_name': transaction.merchant_name,
-                'merchant_category': transaction.merchant_category,
-                'description': transaction.description,
-                'currency': transaction.currency,
-                'credit_card_num': transaction.credit_card_num,
-                'merchant_city': transaction.merchant_city,
-                'merchant_state': transaction.merchant_state,
-                'merchant_country': transaction.merchant_country,
-                'trans_num': transaction.trans_num,
-                'authorization_code': transaction.authorization_code,
-            }
-
-            sql_query = parse_alert_to_sql_with_context(
-                transaction_dict, rule.natural_language_query
-            )
-
-            # Store the generated SQL query for future use
-            await session.execute(
-                update(AlertRule)
-                .where(AlertRule.id == rule.id)
-                .values(sql_query=sql_query)
-            )
-
-        # Execute the SQL query
-        from .alerts.agents.sql_executor import execute_sql
-
-        query_result = execute_sql(sql_query)
-
-        # Check if alert should be triggered
-        alert_triggered = self._should_trigger_alert(query_result)
-
-        if alert_triggered:
-            await self._create_and_send_notification(
-                transaction, rule, query_result, session
-            )
-
-    def _should_trigger_alert(self, query_result: str) -> bool:
-        """Determine if an alert should be triggered based on query result"""
+        # For each new transaction, trigger the alert rule using the existing service
         try:
-            # Check if query returned results and doesn't indicate error
-            return (
-                query_result
-                and not query_result.startswith('SQL Error')
-                and query_result != '[]'
-                and query_result.strip() != ''
+            trigger_result = await self.alert_rule_service.trigger_alert_rule(
+                rule, session
             )
-        except Exception:
-            return False
 
-    async def _create_and_send_notification(
-        self,
-        transaction: Transaction,
-        rule: AlertRule,
-        query_result: str,
-        session: AsyncSession,
-    ):
-        """Create and send a notification for a triggered alert"""
+            if trigger_result.get('status') == 'triggered':
+                logger.info(f'Alert {rule.id} triggered successfully')
+            elif trigger_result.get('status') == 'not_triggered':
+                logger.debug(f'Alert {rule.id} evaluated but not triggered')
+            else:
+                logger.warning(
+                    f'Alert {rule.id} evaluation returned: {trigger_result.get("status")}'
+                )
 
-        # Generate alert message using LLM
-        from .alerts.agents.generate_alert_message import generate_alert_message
-
-        context = {
-            'transaction': transaction.__dict__,
-            'query_result': query_result,
-            'alert_text': rule.natural_language_query,
-            'alert_rule': {
-                'name': rule.name,
-                'description': rule.description,
-                'alert_type': str(rule.alert_type),
-            },
-        }
-
-        try:
-            alert_message = generate_alert_message(context)
+        except ValueError as e:
+            logger.warning(f'Alert rule {rule.id} could not be triggered: {e}')
         except Exception as e:
-            logger.error(f'Error generating alert message: {e}')
-            alert_message = f'Alert triggered: {rule.name} - Transaction amount: ${transaction.amount}'
-
-        # Create notification
-        AlertNotification(
-            id=str(uuid.uuid4()),
-            user_id=rule.user_id,
-            alert_rule_id=rule.id,
-            transaction_id=transaction.id,
-            title=f'Alert: {rule.name}',
-            message=alert_message,
-            notification_method=NotificationMethod.EMAIL,  # Default to email
-            status=NotificationStatus.PENDING,
-        )
-
-        # Send notification based on rule's notification methods
-        notification_methods = rule.notification_methods or [NotificationMethod.EMAIL]
-
-        for method in notification_methods:
-            try:
-                notification_copy = AlertNotification(
-                    id=str(uuid.uuid4()),
-                    user_id=rule.user_id,
-                    alert_rule_id=rule.id,
-                    transaction_id=transaction.id,
-                    title=f'Alert: {rule.name}',
-                    message=alert_message,
-                    notification_method=method,
-                    status=NotificationStatus.PENDING,
-                )
-
-                # Send notification
-                if method == NotificationMethod.EMAIL:
-                    strategy = SmtpStrategy()
-                else:
-                    strategy = NoopStrategy()  # For now, only email is implemented
-
-                ctx = Context(strategy)
-                sent_notification = await ctx.send_notification(
-                    notification_copy, session
-                )
-
-                session.add(sent_notification)
-                logger.info(f'Notification sent via {method} for alert {rule.id}')
-
-            except Exception as e:
-                logger.error(f'Error sending notification via {method}: {e}')
-
-        # Update rule trigger count and last triggered time
-        await session.execute(
-            update(AlertRule)
-            .where(AlertRule.id == rule.id)
-            .values(
-                trigger_count=rule.trigger_count + 1,
-                last_triggered=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
-            )
-        )
-
-        logger.info(f'Alert {rule.id} triggered for transaction {transaction.id}')
+            logger.error(f'Error triggering alert rule {rule.id}: {e}')
 
 
 # Global monitor instance


### PR DESCRIPTION
## Description

- Replaced _should_trigger_alert,_evaluate_transaction_against_rule, and _create_and_send_notification methods with a single call to alert_rule_service.trigger_alert_rule()
- Added proper email notification sending in alert_rule_service.py using SmtpStrategy
- Improved error handling and logging for alert processing
- Maintains user isolation and transaction detection while simplifying architecture

This consolidates alert processing logic into a single service and leverages existing LLM processing, SQL generation, and notification infrastructure.