### PR TITLE
fix(compose): use the correct port for smtp4dev

### DIFF
--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -28,7 +28,9 @@ services:
     container_name: spending-monitor-smtp
     ports:
       - "3002:80"   # Web UI
-      - "2525:25"   # SMTP Port
+      # smtp4dev listens on port 25 for incoming SMTP traffic.
+      # Uncomment the following line to also accept SMTP traffic from the host on port 2525.
+      # - "2525:25"
     networks:
       - spending-monitor
 
@@ -42,7 +44,7 @@ services:
     environment:
       - DATABASE_URL=postgresql+asyncpg://user:password@postgres:5432/spending-monitor
       - SMTP_HOST=smtp4dev
-      - SMTP_PORT=2525
+      - SMTP_PORT=25
       - SMTP_USERNAME=
       - SMTP_PASSWORD=
       - SMTP_FROM_EMAIL=spending-monitor@localhost


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? Include context/background if helpful. -->
Follow-up fixes for the port number of smtp4dev in local deployment introduced in #49.

Unless smtp4dev needs to accept SMTP traffic from the host, port 25 doesn't need to be exposed.

## Related issues

None


## How was this tested / what tests were added?

- Manual: `make build-run-local`, then try sending a notification and confirm it shows up in smtp4dev


## Screenshots or recordings (if applicable)

None

## Documentation updates

<!-- Describe any docs updates or additions -->
- [x] Changes are self documenting
- [ ] Inline docs added
- [ ] Formal docs added