### PR TITLE
fix(api): move smtp config into unified config system

### DIFF
--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -74,6 +74,16 @@ class Settings(BaseSettings):
     KEYCLOAK_REALM: str = 'spending-monitor'
     KEYCLOAK_CLIENT_ID: str = 'spending-monitor'
 
+    # SMTP settings
+    SMTP_HOST: str = 'localhost'
+    SMTP_PORT: int = 8025
+    SMTP_USERNAME: str = ''
+    SMTP_PASSWORD: str = ''
+    SMTP_FROM_EMAIL: str = 'noreply@localhost'
+    SMTP_REPLY_TO_EMAIL: str = 'noreply@localhost'
+    SMTP_USE_TLS: bool = True
+    SMTP_USE_SSL: bool = False
+
     def model_post_init(self, __context):
         """Set derived values based on environment"""
         # Auto-enable auth bypass in development if not explicitly set

--- a/packages/api/src/services/smtp.py
+++ b/packages/api/src/services/smtp.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import logging
-import os
 import smtplib
 
-from dotenv import load_dotenv
 from fastapi import HTTPException
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
@@ -13,8 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import AlertNotification, NotificationStatus, User
 
-# Load environment variables from .env file
-load_dotenv()
+from ..core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -26,31 +23,6 @@ class EmailNotification(BaseModel):
     html_body: str | None = None
     from_email: str | None = None
     reply_to: str | None = None
-
-
-class SMTPConfig(BaseModel):
-    host: str
-    port: int
-    username: str
-    password: str
-    from_email: str
-    reply_to_email: str
-    use_tls: bool = True
-    use_ssl: bool = False
-
-
-smtp_details = {
-    'host': os.getenv('SMTP_HOST', 'localhost'),
-    'port': int(os.getenv('SMTP_PORT', 8025)),
-    'username': os.getenv('SMTP_USERNAME', ''),
-    'password': os.getenv('SMTP_PASSWORD', ''),
-    'from_email': os.getenv('SMTP_FROM_EMAIL', 'noreply@localhost'),
-    'reply_to_email': os.getenv('SMTP_REPLY_TO_EMAIL', 'noreply@localhost'),
-    'use_tls': os.getenv('SMTP_USE_TLS', 'true').lower() == 'true',
-    'use_ssl': os.getenv('SMTP_USE_SSL', 'false').lower() == 'true',
-}
-
-smtp_config = SMTPConfig(**smtp_details)
 
 
 async def send_smtp_notification(
@@ -70,10 +42,10 @@ async def send_smtp_notification(
         # Create message
         msg = MIMEMultipart('alternative')
         msg['Subject'] = notification.title
-        msg['From'] = smtp_config.from_email or smtp_config.username
+        msg['From'] = settings.SMTP_FROM_EMAIL or settings.SMTP_USERNAME
 
-        if smtp_config.reply_to_email:
-            msg['Reply-To'] = smtp_config.reply_to_email
+        if settings.SMTP_REPLY_TO_EMAIL:
+            msg['Reply-To'] = settings.SMTP_REPLY_TO_EMAIL
 
         # Add plain text body
         text_part = MIMEText(notification.message, 'plain')
@@ -85,15 +57,15 @@ async def send_smtp_notification(
         #     msg.attach(html_part)
 
         # Connect to SMTP server
-        if smtp_config.use_ssl:
-            server = smtplib.SMTP_SSL(smtp_config.host, smtp_config.port)
+        if settings.SMTP_USE_SSL:
+            server = smtplib.SMTP_SSL(settings.SMTP_HOST, settings.SMTP_PORT)
         else:
-            server = smtplib.SMTP(smtp_config.host, smtp_config.port)
-            if smtp_config.use_tls:
+            server = smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT)
+            if settings.SMTP_USE_TLS:
                 server.starttls()
 
-        if smtp_config.username and smtp_config.password:
-            server.login(smtp_config.username, smtp_config.password)
+        if settings.SMTP_USERNAME and settings.SMTP_PASSWORD:
+            server.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
 
         # Send email
         try:


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? Include context/background if helpful. -->
This PR removes dotenv/configuration-loading code from the smtp module and moves it into core.config, adjusting usages of the config to point at core.config. This makes it easier to keep track of all the config needed to run the API and avoids duplicating dotenv-related code.

## Related issues

- Closes #
- Related to #


## How was this tested / what tests were added?

<!-- Describe the testing approach. List new/updated tests and any manual steps. -->
- Automated:

- Manual:


## Screenshots or recordings (if applicable)

<!-- Add before/after visuals, GIFs, or console output when UI/UX changes are involved. -->


## Documentation updates

<!-- Describe any docs updates or additions -->
- [x] Changes are self documenting
- [ ] Inline docs added
- [ ] Formal docs added