### PR TITLE
fix: move environment variables from deployments to secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,30 +23,29 @@ ENV_FILE_PROD = .env.production
 ENV_FILE = $(ENV_FILE_DEV)  # Default to development for backwards compatibility
 
 # Helper function to generate helm parameters from environment variables
-define HELM_ENV_PARAMS
---set database.env.POSTGRES_DB="$$POSTGRES_DB" \
---set database.env.POSTGRES_USER="$$POSTGRES_USER" \
---set database.env.POSTGRES_PASSWORD="$$POSTGRES_PASSWORD" \
---set-string api.env.DATABASE_URL="$$DATABASE_URL" \
---set-string api.env.API_KEY="$$API_KEY" \
---set-string api.env.BASE_URL="$$BASE_URL" \
---set api.env.LLM_PROVIDER="$$LLM_PROVIDER" \
---set api.env.MODEL="$$MODEL" \
---set api.env.ENVIRONMENT="$$ENVIRONMENT" \
---set api.env.DEBUG="$$DEBUG" \
---set api.env.BYPASS_AUTH="$$BYPASS_AUTH" \
---set-string api.env.CORS_ALLOWED_ORIGINS="$$CORS_ALLOWED_ORIGINS" \
---set-string api.env.ALLOWED_ORIGINS="$$ALLOWED_ORIGINS" \
---set-string api.env.ALLOWED_HOSTS="$$ALLOWED_HOSTS" \
---set-string api.env.SMTP_HOST="$$SMTP_HOST" \
---set api.env.SMTP_PORT="$$SMTP_PORT" \
---set-string api.env.SMTP_FROM_EMAIL="$$SMTP_FROM_EMAIL" \
---set api.env.SMTP_USE_TLS="$$SMTP_USE_TLS" \
---set api.env.SMTP_USE_SSL="$$SMTP_USE_SSL" \
---set-string api.env.KEYCLOAK_URL="$$KEYCLOAK_URL" \
---set api.env.KEYCLOAK_REALM="$$KEYCLOAK_REALM" \
---set api.env.KEYCLOAK_CLIENT_ID="$$KEYCLOAK_CLIENT_ID" \
---set-string ui.env.VITE_API_BASE_URL="$$VITE_API_BASE_URL"
+define HELM_SECRET_PARAMS
+--set secrets.POSTGRES_DB="$$POSTGRES_DB" \
+--set secrets.POSTGRES_USER="$$POSTGRES_USER" \
+--set secrets.POSTGRES_PASSWORD="$$POSTGRES_PASSWORD" \
+--set secrets.DATABASE_URL="$$DATABASE_URL" \
+--set secrets.API_KEY="$$API_KEY" \
+--set secrets.BASE_URL="$$BASE_URL" \
+--set secrets.LLM_PROVIDER="$$LLM_PROVIDER" \
+--set secrets.MODEL="$$MODEL" \
+--set secrets.ENVIRONMENT="$$ENVIRONMENT" \
+--set secrets.DEBUG="$$DEBUG" \
+--set secrets.BYPASS_AUTH="$$BYPASS_AUTH" \
+--set secrets.CORS_ALLOWED_ORIGINS="$${CORS_ALLOWED_ORIGINS//,/\\,}" \
+--set secrets.ALLOWED_ORIGINS="$${ALLOWED_ORIGINS//,/\\,}" \
+--set secrets.SMTP_HOST="$$SMTP_HOST" \
+--set secrets.SMTP_PORT="$$SMTP_PORT" \
+--set secrets.SMTP_FROM_EMAIL="$$SMTP_FROM_EMAIL" \
+--set secrets.SMTP_USE_TLS="$$SMTP_USE_TLS" \
+--set secrets.SMTP_USE_SSL="$$SMTP_USE_SSL" \
+--set secrets.KEYCLOAK_URL="$$KEYCLOAK_URL" \
+--set secrets.KEYCLOAK_REALM="$$KEYCLOAK_REALM" \
+--set secrets.KEYCLOAK_CLIENT_ID="$$KEYCLOAK_CLIENT_ID" \
+--set secrets.VITE_API_BASE_URL="$$VITE_API_BASE_URL"
 endef
 
 # Default target when running 'make' without arguments
@@ -339,7 +338,7 @@ deploy: create-project check-env-prod
 		--set global.imageRegistry=$(REGISTRY_URL) \
 		--set global.imageRepository=$(REPOSITORY) \
 		--set global.imageTag=$(IMAGE_TAG) \
-		$(HELM_ENV_PARAMS)
+		$(HELM_SECRET_PARAMS)
 
 .PHONY: deploy-dev
 deploy-dev: create-project check-env-prod
@@ -356,7 +355,7 @@ deploy-dev: create-project check-env-prod
 		--set database.persistence.enabled=false \
 		--set api.replicas=1 \
 		--set ui.replicas=1 \
-		$(HELM_ENV_PARAMS)
+		$(HELM_SECRET_PARAMS)
 
 .PHONY: deploy-all
 deploy-all: build-all push-all deploy
@@ -410,7 +409,7 @@ helm-template: check-env-prod
 		--set global.imageRegistry=$(REGISTRY_URL) \
 		--set global.imageRepository=$(REPOSITORY) \
 		--set global.imageTag=$(IMAGE_TAG) \
-		$(HELM_ENV_PARAMS)
+		$(HELM_SECRET_PARAMS)
 
 .PHONY: helm-debug
 helm-debug: check-env-prod
@@ -423,7 +422,7 @@ helm-debug: check-env-prod
 		--set global.imageRegistry=$(REGISTRY_URL) \
 		--set global.imageRepository=$(REPOSITORY) \
 		--set global.imageTag=$(IMAGE_TAG) \
-		$(HELM_ENV_PARAMS) \
+		$(HELM_SECRET_PARAMS) \
 		--dry-run --debug
 
 # Clean up targets

--- a/deploy/helm/spending-monitor/templates/api-deployment.yaml
+++ b/deploy/helm/spending-monitor/templates/api-deployment.yaml
@@ -29,10 +29,96 @@ spec:
               containerPort: 8000
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.api.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: DATABASE_URL
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: API_KEY
+            - name: BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: BASE_URL
+            - name: LLM_PROVIDER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: LLM_PROVIDER
+            - name: MODEL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: MODEL
+            - name: ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: ENVIRONMENT
+            - name: DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: DEBUG
+            - name: BYPASS_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: BYPASS_AUTH
+            - name: CORS_ALLOWED_ORIGINS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: CORS_ALLOWED_ORIGINS
+            - name: ALLOWED_ORIGINS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: ALLOWED_ORIGINS
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: SMTP_HOST
+            - name: SMTP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: SMTP_PORT
+            - name: SMTP_FROM_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: SMTP_FROM_EMAIL
+            - name: SMTP_USE_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: SMTP_USE_TLS
+            - name: SMTP_USE_SSL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: SMTP_USE_SSL
+            - name: KEYCLOAK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: KEYCLOAK_URL
+            - name: KEYCLOAK_REALM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: KEYCLOAK_REALM
+            - name: KEYCLOAK_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: KEYCLOAK_CLIENT_ID
           {{- if .Values.api.healthCheck.enabled }}
           livenessProbe:
             httpGet:

--- a/deploy/helm/spending-monitor/templates/database-deployment.yaml
+++ b/deploy/helm/spending-monitor/templates/database-deployment.yaml
@@ -29,10 +29,21 @@ spec:
               containerPort: 5432
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.database.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           volumeMounts:

--- a/deploy/helm/spending-monitor/templates/migration-job.yaml
+++ b/deploy/helm/spending-monitor/templates/migration-job.yaml
@@ -30,14 +30,27 @@ spec:
             - -c
             - |
               echo "Waiting for database to be ready..."
-              until pg_isready -h {{ .Values.database.name }} -U {{ .Values.database.env.POSTGRES_USER }} -d {{ .Values.database.env.POSTGRES_DB }}; do
+              until pg_isready -h {{ .Values.database.name }} -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
                 echo "Database not ready, waiting..."
                 sleep 5
               done
               echo "Database is ready!"
           env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_DB
             - name: PGPASSWORD
-              value: {{ .Values.database.env.POSTGRES_PASSWORD | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_PASSWORD
       containers:
         - name: migration
           securityContext:
@@ -49,13 +62,25 @@ spec:
             - name: POSTGRES_HOST
               value: {{ .Values.database.name | quote }}
             - name: POSTGRES_DB
-              value: {{ .Values.database.env.POSTGRES_DB | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_DB
             - name: POSTGRES_USER
-              value: {{ .Values.database.env.POSTGRES_USER | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.database.env.POSTGRES_PASSWORD | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: POSTGRES_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql+asyncpg://{{ .Values.database.env.POSTGRES_USER }}:{{ .Values.database.env.POSTGRES_PASSWORD }}@{{ .Values.database.name }}:5432/{{ .Values.database.env.POSTGRES_DB }}"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: DATABASE_URL
             # Python path for module imports
             - name: PYTHONPATH
               value: "/app/packages/db/src:/app/packages/api/src"

--- a/deploy/helm/spending-monitor/templates/secret.yaml
+++ b/deploy/helm/spending-monitor/templates/secret.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spending-monitor.fullname" . }}-secret
+  labels:
+    {{- include "spending-monitor.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # Database environment variables
+  POSTGRES_DB: {{ .Values.secrets.POSTGRES_DB | toString | b64enc | quote }}
+  POSTGRES_USER: {{ .Values.secrets.POSTGRES_USER | toString | b64enc | quote }}
+  POSTGRES_PASSWORD: {{ .Values.secrets.POSTGRES_PASSWORD | toString | b64enc | quote }}
+
+  # API environment variables
+  DATABASE_URL: {{ .Values.secrets.DATABASE_URL | toString | b64enc | quote }}
+  API_KEY: {{ .Values.secrets.API_KEY | toString | b64enc | quote }}
+  BASE_URL: {{ .Values.secrets.BASE_URL | toString | b64enc | quote }}
+  LLM_PROVIDER: {{ .Values.secrets.LLM_PROVIDER | toString | b64enc | quote }}
+  MODEL: {{ .Values.secrets.MODEL | toString | b64enc | quote }}
+  ENVIRONMENT: {{ .Values.secrets.ENVIRONMENT | toString | b64enc | quote }}
+  DEBUG: {{ .Values.secrets.DEBUG | toString | b64enc | quote }}
+  BYPASS_AUTH: {{ .Values.secrets.BYPASS_AUTH | toString | b64enc | quote }}
+  CORS_ALLOWED_ORIGINS: {{ .Values.secrets.CORS_ALLOWED_ORIGINS | toString | b64enc | quote }}
+  ALLOWED_ORIGINS: {{ .Values.secrets.ALLOWED_ORIGINS | toString | b64enc | quote }}
+  SMTP_HOST: {{ .Values.secrets.SMTP_HOST | toString | b64enc | quote }}
+  SMTP_PORT: {{ .Values.secrets.SMTP_PORT | toString | b64enc | quote }}
+  SMTP_FROM_EMAIL: {{ .Values.secrets.SMTP_FROM_EMAIL | toString | b64enc | quote }}
+  SMTP_USE_TLS: {{ .Values.secrets.SMTP_USE_TLS | toString | b64enc | quote }}
+  SMTP_USE_SSL: {{ .Values.secrets.SMTP_USE_SSL | toString | b64enc | quote }}
+  KEYCLOAK_URL: {{ .Values.secrets.KEYCLOAK_URL | toString | b64enc | quote }}
+  KEYCLOAK_REALM: {{ .Values.secrets.KEYCLOAK_REALM | toString | b64enc | quote }}
+  KEYCLOAK_CLIENT_ID: {{ .Values.secrets.KEYCLOAK_CLIENT_ID | toString | b64enc | quote }}
+
+  # UI environment variables
+  VITE_API_BASE_URL: {{ .Values.secrets.VITE_API_BASE_URL | toString | b64enc | quote }}

--- a/deploy/helm/spending-monitor/templates/ui-deployment.yaml
+++ b/deploy/helm/spending-monitor/templates/ui-deployment.yaml
@@ -29,10 +29,11 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            {{- range $key, $value := .Values.ui.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+            - name: VITE_API_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spending-monitor.fullname" . }}-secret
+                  key: VITE_API_BASE_URL
           {{- if .Values.ui.healthCheck.enabled }}
           livenessProbe:
             httpGet:

--- a/deploy/helm/spending-monitor/values.yaml
+++ b/deploy/helm/spending-monitor/values.yaml
@@ -6,6 +6,36 @@ global:
   imagePullPolicy: IfNotPresent
   storageClass: ""
 
+# Secrets configuration - these values should be overridden with actual secrets
+secrets:
+  # Database secrets
+  POSTGRES_DB: "spending-monitor"
+  POSTGRES_USER: "user"
+  POSTGRES_PASSWORD: "changeme"
+
+  # API secrets
+  DATABASE_URL: "postgresql+asyncpg://user:changeme@spending-monitor-db:5432/spending-monitor"
+  API_KEY: "changeme"
+  BASE_URL: "http://localhost:8000"
+  LLM_PROVIDER: "openai"
+  MODEL: "llama-3-3-70b-instruct-w8a8"
+  ENVIRONMENT: "production"
+  DEBUG: "false"
+  BYPASS_AUTH: "false"
+  CORS_ALLOWED_ORIGINS: '["*"]'
+  ALLOWED_ORIGINS: '["*"]'
+  SMTP_HOST: "changeme"
+  SMTP_PORT: "587"
+  SMTP_FROM_EMAIL: "changeme"
+  SMTP_USE_TLS: "true"
+  SMTP_USE_SSL: "false"
+  KEYCLOAK_URL: "changeme"
+  KEYCLOAK_REALM: "changeme"
+  KEYCLOAK_CLIENT_ID: "changeme"
+
+  # UI secrets
+  VITE_API_BASE_URL: "http://localhost:8000"
+
 # Database configuration
 database:
   enabled: true
@@ -20,10 +50,6 @@ database:
     enabled: true
     size: 10Gi
     accessMode: ReadWriteOnce
-  env:
-    POSTGRES_DB: spending-monitor
-    POSTGRES_USER: user
-    POSTGRES_PASSWORD: password
   resources:
     requests:
       memory: "256Mi"
@@ -61,15 +87,6 @@ api:
     type: ClusterIP
     port: 8000
   replicas: 1
-  env:
-    DATABASE_URL: postgresql+asyncpg://user:password@spending-monitor-db:5432/spending-monitor
-    ENVIRONMENT: production
-    NODE_ENV: production
-    DEBUG: "false"
-    ALLOWED_HOSTS: '["*"]'
-    APP_NAME: spending-monitor
-    LLM_PROVIDER: openai
-    MODEL: "llama-3-3-70b-instruct-w8a8"
   resources:
     requests:
       memory: "512Mi"
@@ -94,7 +111,6 @@ ui:
     type: ClusterIP
     port: 8080
   replicas: 1
-  env: {}
   resources:
     requests:
       memory: "128Mi"


### PR DESCRIPTION
## Description

- Create new secret template with all environment variables
- Update all deployments to reference secret instead of inline env vars:
  - Database deployment: POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
  - API deployment: all API configuration variables
  - UI deployment: VITE_API_BASE_URL
  - Migration job: database connection variables
- Update Makefile to use secrets structure instead of env parameters
- Add proper value escaping for comma-separated CORS origins
- Use toString filter in secret template to handle boolean values
- Remove problematic ALLOWED_HOSTS from secret (uses default value)
- Clean up old env sections from values.yaml


## Related issues

- Closes #69  
